### PR TITLE
Rename library to Nucleux and improve API terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ _Simple, atomic hub for all your application's state management needs._
 
 Nucleux is a simple, atomic state management library based on the publisher-subscriber pattern and inversion-of-control (IoC) container design principle.
 
-Nucleux allows you to have centralized locations (stores) with units of state (atoms) that your application can subscribe to. Unlike other state management libraries, Nucleux only triggers strictly-needed, isolated updates for computations (e.g. React components) subscribed to atoms.
+Nucleux allows you to create centralized stores with atomic units of state that your application can subscribe to. Unlike other state management libraries, Nucleux only triggers strictly-needed, isolated updates for computations (e.g. React components) subscribed to specific atoms.
 
-With Nucleux you can manage your application state outside of any UI framework, making your code decoupled, portable, and testable.
+With Nucleux, you can manage your application state outside of any UI framework, making your code decoupled, portable, and testable.
 
 ## Why Nucleux over other state management libraries?
 
 - Simple and un-opinionated
 - Makes hooks the primary means of consuming state
 - Less boilerplate and no provider wrapping
-- Centralized, atomic and subscription-based state management
+- Centralized, atomic, and subscription-based state management
 
 ## Table of contents
 
@@ -26,7 +26,7 @@ With Nucleux you can manage your application state outside of any UI framework, 
 - [A Quick Example](#a-quick-example)
 - [Description](#description)
 - [Detailed Usage](#detailed-usage)
-- [Dependency](#dependency-injection)
+- [Dependency Injection](#dependency-injection)
 - [Persistency](#persistency)
 - [Computed Values](#computed-values)
 - [React Native](#react-native)
@@ -65,7 +65,9 @@ const CounterView = () => {
   const count = useValue(counterStore.count);
 
   return (
-    <button onClick={counterStore.increment}>Current Count: {count}</button>
+    <button onClick={() => counterStore.increment()}>
+      Current Count: {count}
+    </button>
   );
 };
 
@@ -74,27 +76,27 @@ ReactDOM.render(<CounterView />, document.body);
 
 ## Description
 
-Nucleux leverages on two software architecture patterns:
+Nucleux leverages two core software architecture patterns:
 
-- IoC Container pattern (a.k.a. DI Container) to manage store instantiation, dependency injection and lifecycle.
-- The publisher-subscriber pattern to implement values within the stores that any JavaScript context (including React components) can subscribe and publish to.
+- IoC Container pattern (a.k.a. DI Container) to manage store instantiation, dependency injection, and lifecycle.
+- Publisher-subscriber pattern to implement atoms within stores that any JavaScript context (including React components) can subscribe and publish to.
 
 ### What's a Store?
 
-A store is essentially a bucket of atoms (values) that other JavaScript objects can subscribe and publish to. The stores live as long as they have at least one reference in the container. Once the last reference of a store is removed, the store is disposed.
+A store is essentially a container of atoms (state values) that other JavaScript objects can subscribe and publish to. Stores live as long as they have at least one reference in the container. Once the last reference of a store is removed, the store is disposed.
 
 ## Detailed Usage
 
-Let's take a closer look on how to use the library.
+Let's take a closer look at how to use the library.
 
 ### Create a store
 
-First, let's create our store. A store is a class that implements the following:
+First, let's create our store. A store is a class that implements:
 
-- Store atom(s) by calling `atom()` with an initial value (required).
-- Value setters that publish (updates) the store values (optional).
+- Store atoms by calling `this.atom()` with an initial value (required).
+- Methods that update the store atoms (optional).
 
-Note: It is a good pattern to keep your stores separate from your UI.
+Note: It's good practice to keep your stores separate from your UI.
 
 ```javascript
 import { Store } from 'nucleux';
@@ -119,34 +121,34 @@ Now that we have our store, we can use it anywhere within a JavaScript applicati
 import { Container } from 'nucleux';
 import CounterStore from './CounterStore';
 
-// get the container and store instances
-const storeContainer = Container.getInstance();
-const counterStore = storeContainer.get(CounterStore);
+// Get the container and store instances
+const container = Container.getInstance();
+const counterStore = container.get(CounterStore);
 
-// subscribe to the value
+// Subscribe to an atom
 const subscriberId = counterStore.count.subscribe((count) => {
   console.log(`Current Count: ${count}`);
 });
 
-// publish to the value
+// Update the atom
 counterStore.increment();
 counterStore.increment();
 counterStore.increment();
 
-// unsubscribe from the value
+// Unsubscribe from the atom
 counterStore.count.unsubscribe(subscriberId);
 
-// dispose the store
-storeContainer.remove(CounterStore);
+// Dispose the store
+container.remove(CounterStore);
 ```
 
 ### Use the store in a React Component
 
-All right, let's use our store in a UI using React (we'll support frameworks in the future).
+Let's use our store in a React component.
 
-First we need to get our store instance by using the `useStore`. Then we can use the hook `useValue` to subscribe to a store atom value and trigger the side effects (render).
+First, we need to get our store instance using `useStore`. Then we use the `useValue` hook to subscribe to a store atom and trigger re-renders when it changes.
 
-By using these hooks, we get automatic value un-subscription and store disposal for free when the component is unmounted.
+These hooks automatically handle atom unsubscription and store disposal when the component unmounts.
 
 ```javascript
 import React from 'react';
@@ -159,7 +161,9 @@ const CounterView = () => {
   const count = useValue(counterStore.count);
 
   return (
-    <button onClick={counterStore.increment}>Current Count: {count}</button>
+    <button onClick={() => counterStore.increment()}>
+      Current Count: {count}
+    </button>
   );
 };
 
@@ -168,15 +172,15 @@ ReactDOM.render(<CounterView />, document.body);
 
 ### See this live
 
-Please visit our [Codesandbox](https://codesandbox.io/p/sandbox/0cwlqq) to see a live example of the React usage.
+Visit our [Codesandbox](https://codesandbox.io/p/sandbox/0cwlqq) to see a live example of Nucleux with React.
 
-## Dependency (injection)
+## Dependency Injection
 
-It's important for all applications to follow software design principles, specifically separation of concerns and segregation.
+It's important for applications to follow software design principles, especially separation of concerns and segregation.
 
-With Nucleux, we can have segregated stores that contain a small meaningful portion of the application's state (atoms) and then leverage the container to inject stores into main stores.
+With Nucleux, you can have segregated stores that contain focused portions of your application's state. You can then leverage the container to inject stores into other stores.
 
-Let's say we have a store that needs to read the count value from our `CounterStore`. We can easily inject the store like this:
+Let's say we have a store that needs to read the count value from our `CounterStore`:
 
 ```javascript
 import { Store } from 'nucleux';
@@ -200,39 +204,39 @@ class ApplicationStore extends Store {
 export default ApplicationStore;
 ```
 
-By extending from `Store`, we get the automatic un-subscription for free when the store is disposed.
+By extending `Store`, you get automatic unsubscription when the store is disposed.
 
 ## Persistency
 
-In order to persist a store value, we need to specify the persist key we would like to use (has to be unique) in the second argument of `Atom`.
+To persist a store atom, specify a unique persistence key as the second argument to `this.atom()`.
 
-Every time the value is published, the value will be persisted. And, the next time the store is instantiated, the value will be rehydrated.
+When the atom's value changes, it will be persisted. The next time the store is instantiated, the value will be rehydrated.
 
 ```javascript
-// assuming CountValue was persisted as 2, count will be hydrated with 2 instead of 0
-count = new Atom(0, 'CountValue');
+// Assuming 'CountValue' was persisted as 2, count will be hydrated with 2 instead of 0
+count = this.atom(0, 'CountValue');
 
-// this will persist the new value
+// This will persist the new value
 this.count.value = currentCount + 1;
 ```
 
 ### Persistency - Custom Storage
 
-You can configure Nucleux values to use custom storage for persistency. For instance, in React Native, you can use `AsyncStorage`:
+You can configure Nucleux atoms to use custom storage for persistence. For instance, in React Native, you can use `AsyncStorage`:
 
 ```javascript
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-count = new Atom(0, 'CountValue', {
+count = this.atom(0, 'CountValue', {
   storage: AsyncStorage,
 });
 ```
 
-## Computed Values
+## Derived Values
 
-Sometimes we have complex stores with several atoms that we then need to use to derive a value from. Nucleux offers derived atoms feature, which allows us to consume store atoms, derive them in a transformer and produce a single result. To do so, we need our store to extend from `Store`.
+Sometimes you need to derive a value from several atoms. Nucleux offers a derived atoms feature that lets you consume multiple atoms, transform them, and produce a single result.
 
-Let's say we have a store that manages the user session, and we have a `isAuth` atom to determine if the user is authenticated. Now, let's say our user store depends on the API store, which has an atom `isConnected` to allow API requests. Given a requirement that we should only allow requests from authenticated users when the API is connected, we can create a computed property called `shouldMakeRequest`, like so:
+For example, let's say we have a user store that manages authentication and depends on an API store that tracks connection status. If we only want to allow requests from authenticated users when the API is connected, we can create a derived atom:
 
 ### ApiStore
 
@@ -266,7 +270,7 @@ class UserStore extends Store {
 export default UserStore;
 ```
 
-With this, `shouldMakeRequest` will watch both `isAuth` and `isConnected` atom and derive a single `boolean` atom as a result. This derived atom can be used as a regular store value anywhere in our app.
+With this, `shouldMakeRequest` will watch both the `isAuth` and `isConnected` atoms and derive a single boolean result. This derived atom can be used anywhere in your app:
 
 ```javascript
 import React, { useEffect } from 'react';
@@ -280,7 +284,7 @@ const App = () => {
 
   useEffect(() => {
     if (shouldMakeRequest) {
-      // make a fetch request
+      // Make a fetch request
     }
   }, [shouldMakeRequest]);
 
@@ -292,11 +296,13 @@ ReactDOM.render(<App />, document.body);
 
 ## React Native
 
-Nucleux uses `nanoid` for a secure unique string ID generation to create value subscriptions and store identifiers. React Native does not have built-in random generator. The following polyfill works for plain React Native and Expo starting with 39.x.
+Nucleux uses `nanoid` for secure unique ID generation for atom subscriptions and store identifiers. Since React Native doesn't have a built-in random generator, you'll need to add a polyfill.
+
+The following setup works for both plain React Native and Expo projects (version 39.x and above):
 
 ```javascript
 // App.jsx
-import 'react-native-get-random-values';
+import 'react-native-get-random-values'; // Add this polyfill before importing Nucleux
 import { View } from 'react-native';
 import { useStore, useValue } from 'nucleux';
 
@@ -306,9 +312,19 @@ export default function App() {
   const store = useStore(YourStore);
   const value = useValue(store.value);
 
-  return <View>{/* ... */}</View>;
+  return <View>{/* Your components here */}</View>;
 }
 ```
+
+First, install the required polyfill:
+
+```sh
+npm install react-native-get-random-values
+# or
+yarn add react-native-get-random-values
+```
+
+Make sure to import the polyfill at the top of your entry file before any Nucleux imports.
 
 ## Author
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,11 +6,11 @@ module.exports = {
     '**/?(*.)+(spec|test).+(ts|tsx|js)',
   ],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    '^.+\\.[t|j]sx?$': 'ts-jest',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.preload.js'],
   testEnvironment: 'jsdom',
-  transformIgnorePatterns: ['/node_modules/(?!nanoid)'],
+  transformIgnorePatterns: ['/node_modules/(?!(nanoid|auto-bind))'],
   moduleNameMapper: {
     '^nanoid(/(.*)|$)': 'nanoid$1',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "nucleux",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nucleux",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
+        "auto-bind": "^5.0.1",
         "nanoid": "^3.3.11",
         "use-sync-external-store": "^1.5.0"
       },
@@ -1953,6 +1954,18 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "nucleux",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Simple, atomic state management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/martyroque/nucleux"
+    "url": "https://github.com/martyroque/nucleux.git"
   },
   "engines": {
     "node": ">=14"
@@ -31,6 +31,7 @@
     "hooks",
     "store",
     "redux",
+    "pubsub",
     "pub/sub",
     "publish",
     "subscribe"
@@ -65,6 +66,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
+    "auto-bind": "^5.0.1",
     "nanoid": "^3.3.11",
     "use-sync-external-store": "^1.5.0"
   },

--- a/src/Atom.ts
+++ b/src/Atom.ts
@@ -28,7 +28,7 @@ export type SupportedStorage = PromisifyMethods<
   Pick<Storage, 'getItem' | 'setItem'>
 >;
 
-export type ValueOptions = {
+export type AtomOptions = {
   storage: SupportedStorage;
 };
 
@@ -38,7 +38,7 @@ class Atom<V> implements AtomInterface<V> {
   private persistKey?: string;
   private storage?: SupportedStorage;
 
-  constructor(initialValue: V, persistKey?: string, options?: ValueOptions) {
+  constructor(initialValue: V, persistKey?: string, options?: AtomOptions) {
     this._value = initialValue;
     this.persistKey = persistKey;
 

--- a/src/Atom.ts
+++ b/src/Atom.ts
@@ -1,12 +1,12 @@
 import { nanoid } from 'nanoid';
 
-interface ReadOnlyValueInterface<V> {
+interface ReadOnlyAtomInterface<V> {
   readonly value: V;
   subscribe: (callback: (value: V) => void) => string;
   unsubscribe: (subId: string) => boolean;
 }
 
-interface ValueInterface<V> extends ReadOnlyValueInterface<V> {
+interface AtomInterface<V> extends ReadOnlyAtomInterface<V> {
   value: V;
 }
 
@@ -32,7 +32,7 @@ export type ValueOptions = {
   storage: SupportedStorage;
 };
 
-class Value<V> implements ValueInterface<V> {
+class Atom<V> implements AtomInterface<V> {
   private _value: V;
   private subscribers: Map<string, Subscriber<V>> = new Map();
   private persistKey?: string;
@@ -113,4 +113,4 @@ class Value<V> implements ValueInterface<V> {
   }
 }
 
-export { ReadOnlyValueInterface, Value, ValueInterface };
+export { Atom, AtomInterface, ReadOnlyAtomInterface };

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1,5 +1,11 @@
 import autoBind from 'auto-bind';
-import { Atom, AtomInterface, ReadOnlyAtomInterface } from './Atom';
+import {
+  Atom,
+  AtomInterface,
+  AtomOptions,
+  ReadOnlyAtomInterface,
+  SupportedStorage,
+} from './Atom';
 import { Injectable } from './Injectable';
 import { StoreInterface } from './types';
 
@@ -16,13 +22,21 @@ type UnwrappedValues<
 abstract class Store extends Injectable implements StoreInterface {
   private subscriptions: Map<string, (subId: string) => boolean> = new Map();
 
+  protected storage?: SupportedStorage;
+
   constructor() {
     super();
     autoBind(this);
   }
 
-  protected atom<V>(val: V): AtomInterface<V> {
-    return new Atom(val);
+  protected atom<V>(
+    initialValue: V,
+    persistKey?: string,
+    options?: AtomOptions,
+  ): AtomInterface<V> {
+    const atomOptions = options ?? (this.storage && { storage: this.storage });
+
+    return new Atom(initialValue, persistKey, atomOptions);
   }
 
   protected watchAtom<V>(

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1,5 +1,6 @@
+import autoBind from 'auto-bind';
 import { Injectable } from './Injectable';
-import { ReadOnlyValueInterface, Value } from './Value';
+import { ReadOnlyValueInterface, Value, ValueInterface } from './Value';
 import { StoreInterface } from './types';
 
 type UnwrappedValue<T> = T extends ReadOnlyValueInterface<infer R> ? R : T;
@@ -15,7 +16,16 @@ type UnwrappedValues<
 abstract class Store extends Injectable implements StoreInterface {
   private subscriptions: Map<string, (subId: string) => boolean> = new Map();
 
-  protected subscribeToStoreValue<V>(
+  constructor() {
+    super();
+    autoBind(this);
+  }
+
+  protected value<V>(val: V): ValueInterface<V> {
+    return new Value(val);
+  }
+
+  protected subscribeToValue<V>(
     storeValue: ReadOnlyValueInterface<V>,
     callback: (value: V) => void,
   ): void {
@@ -50,7 +60,7 @@ abstract class Store extends Injectable implements StoreInterface {
     }
 
     storeValues.forEach((storeValue) => {
-      this.subscribeToStoreValue(storeValue, computedValueCallback);
+      this.subscribeToValue(storeValue, computedValueCallback);
     });
 
     return computedValue;

--- a/src/__tests__/Atom.test.ts
+++ b/src/__tests__/Atom.test.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import { Value } from '../Value';
+import { Atom } from '../Atom';
 
 jest.mock('nanoid');
 
@@ -9,7 +9,7 @@ jest.mocked(nanoid).mockReturnValue(mockSubId);
 const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
 const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
 
-describe('Value tests', () => {
+describe('Atom tests', () => {
   afterEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
@@ -18,7 +18,7 @@ describe('Value tests', () => {
   describe('getter tests', () => {
     it('should get the current value', () => {
       const initialValue = 'test value';
-      const value = new Value(initialValue);
+      const value = new Atom(initialValue);
 
       expect(value.value).toBe(initialValue);
     });
@@ -26,7 +26,7 @@ describe('Value tests', () => {
 
   describe('publish tests', () => {
     it('should update to the new value', () => {
-      const value = new Value('');
+      const value = new Atom('');
 
       value.value = 'test';
 
@@ -38,7 +38,7 @@ describe('Value tests', () => {
         const expectedValue = 'initial value';
         const persistedKey = 'persisted_key';
         const newValue = 'test';
-        const value = new Value(expectedValue, persistedKey);
+        const value = new Atom(expectedValue, persistedKey);
 
         await new Promise(process.nextTick);
 
@@ -51,7 +51,7 @@ describe('Value tests', () => {
       });
 
       it('should not persist the new value if persist key is not defined', () => {
-        const value = new Value<number>(2);
+        const value = new Atom<number>(2);
 
         value.value = 3;
 
@@ -60,7 +60,7 @@ describe('Value tests', () => {
 
       it('should not persist the new value if persist key is defined and value has not changed', () => {
         const persistedKey = 'persisted_key';
-        const value = new Value(2, persistedKey);
+        const value = new Atom(2, persistedKey);
         setItemSpy.mockClear();
 
         value.value = 2;
@@ -70,7 +70,7 @@ describe('Value tests', () => {
 
       it('should not persist the new value if persist key is defined and value is undefined', () => {
         const persistedKey = 'persisted_key';
-        const value = new Value<number | undefined>(2, persistedKey);
+        const value = new Atom<number | undefined>(2, persistedKey);
         setItemSpy.mockClear();
 
         value.value = undefined;
@@ -82,7 +82,7 @@ describe('Value tests', () => {
 
   describe('subscribe tests', () => {
     it('should create the subscription', () => {
-      const value = new Value('');
+      const value = new Atom('');
       const callback = jest.fn();
       value.subscribe(callback);
 
@@ -93,7 +93,7 @@ describe('Value tests', () => {
     });
 
     it('should return the subscription ID', () => {
-      const value = new Value(null);
+      const value = new Atom(null);
 
       expect(value.subscribe(() => undefined)).toBe(mockSubId);
     });
@@ -101,13 +101,13 @@ describe('Value tests', () => {
 
   describe('unsubscribe tests', () => {
     it('should return false if subscriber ID is not found', () => {
-      const value = new Value('');
+      const value = new Atom('');
 
       expect(value.unsubscribe('subId')).toBe(false);
     });
 
     it('should return true if the subscriber ID is found and deleted', () => {
-      const value = new Value('');
+      const value = new Atom('');
       const callback = jest.fn();
       const subId = value.subscribe(callback);
 
@@ -123,11 +123,11 @@ describe('Value tests', () => {
     it('should hydrate persisted value when persisted value exists', async () => {
       const expectedValue = [1, 2, 3];
       const persistedKey = 'persisted_key';
-      new Value(expectedValue, persistedKey);
+      new Atom(expectedValue, persistedKey);
 
       await new Promise(process.nextTick);
 
-      const value = new Value(null, persistedKey);
+      const value = new Atom(null, persistedKey);
 
       await new Promise(process.nextTick);
 
@@ -139,7 +139,7 @@ describe('Value tests', () => {
       const expectedValue = false;
       const persistedKey = 'persisted_key';
 
-      const value = new Value(expectedValue, persistedKey);
+      const value = new Atom(expectedValue, persistedKey);
 
       await new Promise(process.nextTick);
 
@@ -151,7 +151,7 @@ describe('Value tests', () => {
     });
 
     it('should not create new persisted value when persisted key is not defined', async () => {
-      new Value(false);
+      new Atom(false);
 
       await new Promise(process.nextTick);
 
@@ -171,7 +171,7 @@ describe('Value tests', () => {
           Promise.resolve(JSON.stringify(expectedValue)),
         );
 
-        const value = new Value(null, persistedKey, {
+        const value = new Atom(null, persistedKey, {
           storage: customStorage,
         });
 
@@ -185,7 +185,7 @@ describe('Value tests', () => {
         const expectedValue = false;
         const persistedKey = 'persisted_key';
 
-        const value = new Value(expectedValue, persistedKey, {
+        const value = new Atom(expectedValue, persistedKey, {
           storage: customStorage,
         });
 
@@ -199,7 +199,7 @@ describe('Value tests', () => {
       });
 
       it('should not create new persisted value when persisted key is not defined', async () => {
-        new Value(false);
+        new Atom(false);
 
         await new Promise(process.nextTick);
 

--- a/src/__tests__/Store.test.ts
+++ b/src/__tests__/Store.test.ts
@@ -4,10 +4,10 @@ import { Value } from '../Value';
 
 const storeContainer = Container.getInstance();
 
-class MockSubStore {
-  testValue = new Value(1);
-  boolValue = new Value(false);
-  stringValue = new Value<string | undefined>(undefined);
+class MockSubStore extends Store {
+  testValue = this.value(1);
+  boolValue = this.value(false);
+  stringValue = this.value<string | undefined>(undefined);
 }
 
 const mockSubscribeCallback = jest.fn();
@@ -24,13 +24,18 @@ class MockStore extends Store {
 
   constructor() {
     super();
-    this.subscribeToStoreValue(this.subStore.testValue, mockSubscribeCallback);
+    this.subscribeToValue(this.subStore.testValue, mockSubscribeCallback);
+  }
+
+  public getComputed() {
+    return this.computed.value;
   }
 }
 
 describe('Store tests', () => {
   let mockStore: MockStore;
   let mockSubStore: MockSubStore;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockStore = storeContainer.get(MockStore);
@@ -41,7 +46,24 @@ describe('Store tests', () => {
     storeContainer.remove(MockStore);
   });
 
-  describe('subscribeToStoreValue', () => {
+  describe('autoBind', () => {
+    it('should automatically bind store methods', () => {
+      const getComputed = mockStore.getComputed;
+
+      expect(getComputed()).toBe(false);
+    });
+  });
+
+  describe('value', () => {
+    it('should return a new value instance', () => {
+      const testValue = mockSubStore.testValue;
+
+      expect(testValue.value).toBe(1);
+      expect(testValue).toBeInstanceOf(Value);
+    });
+  });
+
+  describe('subscribeToValue', () => {
     it('should subscribe to any store value', () => {
       mockSubStore.testValue.value = 2;
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -1,12 +1,12 @@
 import { act, renderHook } from '@testing-library/react';
 
-import { Value } from '../Value';
 import { useStore, useValue } from '../hooks';
+import { Store } from '../Store';
 
 const mockDestroy = jest.fn();
 
-class MockStore {
-  testValue = new Value(1);
+class MockStore extends Store {
+  testValue = this.atom(1);
   destroy = mockDestroy;
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,9 +1,9 @@
 import { useCallback, useMemo } from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 
+import { ReadOnlyAtomInterface } from './Atom';
 import { Container } from './Container';
 import { StoreConstructable } from './types';
-import { ReadOnlyValueInterface } from './Value';
 
 function useStore<S>(store: StoreConstructable<S>): S {
   const container = Container.getInstance();
@@ -23,15 +23,16 @@ function useStore<S>(store: StoreConstructable<S>): S {
   return useSyncExternalStore(cleanup, getStore);
 }
 
-function useValue<V>(storeValue: ReadOnlyValueInterface<V>): V {
+function useValue<V>(atom: ReadOnlyAtomInterface<V>): V {
   const subscribe = useCallback((onStoreChange: () => void) => {
-    const subId = storeValue.subscribe(onStoreChange);
+    const subId = atom.subscribe(onStoreChange);
 
     return () => {
-      storeValue.unsubscribe(subId);
+      atom.unsubscribe(subId);
     };
   }, []);
-  const getter = useCallback(() => storeValue.value, [storeValue.value]);
+
+  const getter = useCallback(() => atom.value, [atom.value]);
 
   return useSyncExternalStore(subscribe, getter);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
+export * from './Atom';
 export * from './Container';
 export * from './hooks';
 export * from './Injectable';
 export * from './Store';
 export * from './types';
-export * from './Value';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",
-    "types": [
-      "node",
-      "jest"
-    ],
+    "types": ["node", "jest"],
     "declaration": true,
     "outDir": "dist",
     "esModuleInterop": true,
@@ -18,7 +15,8 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "allowJs": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "src/**/*.spec.ts", "src/**/*.test.ts"]


### PR DESCRIPTION
This PR renames the library from "App's Digest" to "Nucleux" and introduces clearer terminology for the API.

Key changes:
- Renamed library to Nucleux
- Improved method naming: value() → atom(), subscribeToValue() → watchAtom(), computedValue() → deriveAtom()
- Updated README with consistent terminology and improved examples
- Enhanced documentation clarity and formatting
- Kept hook names useStore and useValue for community familiarity

These changes make the API more intuitive while maintaining compatibility with React ecosystem conventions.