### PR TITLE
Release Nucleux v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+## [1.2.0] - 2025-05-10
+
+### Added
+
+- New useNucleux hook for accessing all store methods and atom values
+  with a single hook
+- Overloaded useValue hook to support direct atom access via store
+  constructor and key name
+- Comprehensive JSDoc documentation for all hooks to improve developer
+  experience
+
+### Changed
+
+- Improved type safety for atom access with StoreProxyAtoms type
+  constraints
+- Enhanced error handling for invalid atom access
+
+### Fixed
+
+- Fixed potential memory leaks in subscription cleanup logic
+- Improved type inference for nested atom values
+
 ## [1.1.1] - 2025-03-31
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nucleux",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nucleux",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "auto-bind": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nucleux",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Simple, atomic state management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR introduces significant improvements to the Nucleux API with the goal of reducing boilerplate and making state access more intuitive while maintaining full type safety.

Key Changes:

- Added useNucleux hook: Provides a unified API to access both methods and atom values from a store in a single hook
- Enhanced useValue hook: Now supports direct atom access via store constructor and key name without needing to retrieve the store first
- Improved documentation: Added comprehensive JSDoc to all hooks for better IDE integration

This implementation preserves all existing behavior and maintains backward compatibility while adding new convenient ways to interact with state.

Testing:

- All existing tests pass
- Added new tests for useNucleux and the enhanced useValue functionality
- Verified type safety constraints in TypeScript