### PR TITLE
Fix race condition in useNucleux hook that prevented component rerenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Documentation
 
+### Fixed
+
+- Fix and improve useNucleux hook
+
 ## [1.2.0] - 2025-05-10
 
 ### Added

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -42,10 +42,15 @@ abstract class Store extends Injectable implements StoreInterface {
   protected watchAtom<V>(
     atom: ReadOnlyAtomInterface<V>,
     callback: (value: V) => void,
+    immediate = false,
   ): void {
     const subId = atom.subscribe(callback);
 
     this.subscriptions.set(subId, atom.unsubscribe);
+
+    if (immediate) {
+      callback(atom.value);
+    }
   }
 
   protected deriveAtom<

--- a/src/__tests__/Store.test.ts
+++ b/src/__tests__/Store.test.ts
@@ -11,6 +11,7 @@ class MockSubStore extends Store {
 }
 
 const mockSubscribeCallback = jest.fn();
+const mockSubscribeImmediateCallback = jest.fn();
 
 class MockStore extends Store {
   public subStore = this.inject(MockSubStore);
@@ -25,6 +26,11 @@ class MockStore extends Store {
   constructor() {
     super();
     this.watchAtom(this.subStore.testValue, mockSubscribeCallback);
+    this.watchAtom(
+      this.subStore.testValue,
+      mockSubscribeImmediateCallback,
+      true,
+    );
   }
 
   public getDerived() {
@@ -64,6 +70,10 @@ describe('Store tests', () => {
   });
 
   describe('watchAtom', () => {
+    it('should receive value immediately upon subscribe', () => {
+      expect(mockSubscribeImmediateCallback).toHaveBeenCalledWith(1);
+    });
+
     it('should subscribe to any store value', () => {
       mockSubStore.testValue.value = 2;
 


### PR DESCRIPTION
The hook wasn't consistently triggering rerenders due to a race condition between atom updates and subscription setup. The fix was to add an `immediate` parameter to the `watchAtom` store method that allows callbacks to receive the current atom value immediately upon subscription, ensuring components always have access to the latest state.

Other changes:
- Improve hook by doing only one iteration to subscribe to store instance atoms.