### PR TITLE
Release Nucleux v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.1] - 2025-05-17
+
 ### Added
 
 - Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nucleux",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nucleux",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "auto-bind": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nucleux",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Simple, atomic state management",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixed a timing issue in the useNucleux hook that occasionally prevented components from re-rendering when atom values changed. The enhancement adds an immediate option to the watchAtom method, allowing subscribers to instantly receive the current atom value upon subscription rather than waiting for the next change. This improvement ensures components consistently render with the most up-to-date state, eliminating race conditions between atom updates and subscription establishment.