### PR TITLE
Add immediate callback option to Atom subscribe method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added immediate callback option to Atom subscribe method.
+
 ## [1.2.1] - 2025-05-17
 
 ### Added

--- a/src/Atom.ts
+++ b/src/Atom.ts
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid';
 
 interface ReadOnlyAtomInterface<V> {
   readonly value: V;
-  subscribe: (callback: (value: V) => void) => string;
+  subscribe: (callback: (value: V) => void, immediate?: boolean) => string;
   unsubscribe: (subId: string) => boolean;
 }
 
@@ -95,10 +95,14 @@ class Atom<V> implements AtomInterface<V> {
     }
   }
 
-  public subscribe(callback: (value: V) => void) {
+  public subscribe(callback: (value: V) => void, immediate = false) {
     const subId = nanoid();
 
     this.subscribers.set(subId, { callback });
+
+    if (immediate) {
+      callback(this.value);
+    }
 
     return subId;
   }

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -44,13 +44,9 @@ abstract class Store extends Injectable implements StoreInterface {
     callback: (value: V) => void,
     immediate = false,
   ): void {
-    const subId = atom.subscribe(callback);
+    const subId = atom.subscribe(callback, immediate);
 
     this.subscriptions.set(subId, atom.unsubscribe);
-
-    if (immediate) {
-      callback(atom.value);
-    }
   }
 
   protected deriveAtom<

--- a/src/__tests__/Atom.test.ts
+++ b/src/__tests__/Atom.test.ts
@@ -97,6 +97,14 @@ describe('Atom tests', () => {
 
       expect(value.subscribe(() => undefined)).toBe(mockSubId);
     });
+
+    it('should get the value when immediate is set', () => {
+      const value = new Atom('immediate');
+      const callback = jest.fn();
+      value.subscribe(callback, true);
+
+      expect(callback).toHaveBeenCalledWith('immediate');
+    });
   });
 
   describe('unsubscribe tests', () => {


### PR DESCRIPTION
This PR addresses race conditions between atom updates and subscription timing by enhancing the Atom's subscribe method with an optional immediate parameter. When set to true, subscribers immediately receive the current atom value upon subscription rather than waiting for the next state change. The watchAtom method has been updated to forward this parameter to the atom's subscribe function, maintaining a consistent API throughout the system. This improvement ensures components using atoms (particularly via useNucleux) always have access to the latest state value, eliminating render inconsistencies caused by subscription timing issues.