### PR TITLE
Add layered memoization support to atoms and derived atoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added social media meta tags to docs for improved link previews.
 - Added favicon to the docs.
 - Added docs analytics.
+- Added layered memoization support to atoms and derived atoms with
+  shallow (default), deep, and custom comparator options to further
+  improve atom updates and component re-renders.
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "auto-bind": "^5.0.1",
+        "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
         "use-sync-external-store": "^1.5.0"
       },
@@ -3252,7 +3253,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "dependencies": {
     "auto-bind": "^5.0.1",
+    "fast-deep-equal": "^3.1.3",
     "nanoid": "^3.3.11",
     "use-sync-external-store": "^1.5.0"
   },

--- a/src/__tests__/Store.test.ts
+++ b/src/__tests__/Store.test.ts
@@ -61,11 +61,144 @@ describe('Store tests', () => {
   });
 
   describe('atom', () => {
-    it('should return a new value instance', () => {
+    it('should return a new atom instance', () => {
       const atom = mockSubStore.testValue;
 
       expect(atom.value).toBe(1);
       expect(atom).toBeInstanceOf(Atom);
+    });
+
+    describe('with options', () => {
+      describe('memoization', () => {
+        it('should prevent unnecessary updates with deep memoization', () => {
+          const callback = jest.fn();
+
+          class TestStore extends Store {
+            user = this.atom(
+              { name: 'John', age: 30 },
+              { memoization: { type: 'deep' } },
+            );
+
+            constructor() {
+              super();
+              this.watchAtom(this.user, callback);
+            }
+          }
+
+          const store = storeContainer.get(TestStore);
+
+          store.user.value = { name: 'John', age: 30 };
+          expect(callback).not.toHaveBeenCalled();
+
+          store.user.value = { name: 'Jane', age: 30 };
+          expect(callback).toHaveBeenCalledWith({ name: 'Jane', age: 30 });
+
+          storeContainer.remove(TestStore);
+        });
+
+        it('should use custom comparator for memoization', () => {
+          const callback = jest.fn();
+
+          class TestStore extends Store {
+            user = this.atom(
+              { name: 'John', age: 30 },
+              {
+                memoization: {
+                  type: 'custom',
+                  compare: (a, b) => a.name === b.name,
+                },
+              },
+            );
+
+            constructor() {
+              super();
+              this.watchAtom(this.user, callback);
+            }
+          }
+
+          const store = storeContainer.get(TestStore);
+
+          store.user.value = { name: 'John', age: 35 };
+          expect(callback).not.toHaveBeenCalled();
+
+          store.user.value = { name: 'Jane', age: 35 };
+          expect(callback).toHaveBeenCalledWith({ name: 'Jane', age: 35 });
+
+          storeContainer.remove(TestStore);
+        });
+      });
+
+      describe('persistence', () => {
+        const customStorage = {
+          setItem: jest.fn(),
+          getItem: jest.fn(),
+        };
+
+        beforeEach(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should not apply store storage to atoms without persistence', () => {
+          class StoreWithStorage extends Store {
+            storage = customStorage;
+            regularAtom = this.atom('no-persistence');
+          }
+
+          const store = storeContainer.get(StoreWithStorage);
+
+          expect(store.regularAtom.value).toBe('no-persistence');
+          expect(customStorage.setItem).not.toHaveBeenCalled();
+
+          storeContainer.remove(StoreWithStorage);
+        });
+
+        it('should use store storage as default for persisted atoms', async () => {
+          class StoreWithStorage extends Store {
+            storage = customStorage;
+            persistedAtom = this.atom('with-persistence', {
+              persistence: { persistKey: 'store-storage-key' },
+            });
+          }
+
+          storeContainer.get(StoreWithStorage);
+
+          await new Promise(process.nextTick);
+
+          expect(customStorage.setItem).toHaveBeenCalledWith(
+            'store-storage-key',
+            JSON.stringify('with-persistence'),
+          );
+
+          storeContainer.remove(StoreWithStorage);
+        });
+
+        it('should allow atom to override store storage', async () => {
+          const atomCustomStorage = {
+            setItem: jest.fn(),
+            getItem: jest.fn(),
+          };
+          class StoreWithStorage extends Store {
+            storage = customStorage;
+            customStorageAtom = this.atom('custom-override', {
+              persistence: {
+                persistKey: 'override-key',
+                storage: atomCustomStorage,
+              },
+            });
+          }
+
+          storeContainer.get(StoreWithStorage);
+
+          await new Promise(process.nextTick);
+
+          expect(atomCustomStorage.setItem).toHaveBeenCalledWith(
+            'override-key',
+            JSON.stringify('custom-override'),
+          );
+
+          storeContainer.remove(StoreWithStorage);
+        });
+      });
     });
   });
 
@@ -111,6 +244,86 @@ describe('Store tests', () => {
       mockSubStore.stringValue.value = 'TEST';
 
       expect(mockStore.derived.value).toBe(false);
+    });
+
+    describe('with memoization', () => {
+      it('should prevent unnecessary updates with deep memoization', () => {
+        const callback = jest.fn();
+
+        class TestStore extends Store {
+          items = this.atom([{ id: 1, name: 'Item 1' }]);
+
+          // Derived atom that returns a new object each time
+          itemSummary = this.deriveAtom(
+            [this.items],
+            (items) => ({
+              count: items.length,
+              names: items.map((i) => i.name),
+            }),
+            { type: 'deep' },
+          );
+
+          constructor() {
+            super();
+            this.watchAtom(this.itemSummary, callback);
+          }
+        }
+
+        const store = storeContainer.get(TestStore);
+
+        // Same items array - derived value content should be the same
+        store.items.value = [{ id: 1, name: 'Item 1' }];
+
+        // Should not trigger callback due to deep equality
+        expect(callback).not.toHaveBeenCalled();
+
+        // Different content - should trigger
+        store.items.value = [
+          { id: 1, name: 'Item 1' },
+          { id: 2, name: 'Item 2' },
+        ];
+        expect(callback).toHaveBeenCalledWith({
+          count: 2,
+          names: ['Item 1', 'Item 2'],
+        });
+
+        storeContainer.remove(TestStore);
+      });
+
+      it('should use custom comparator for derived atoms', () => {
+        const callback = jest.fn();
+
+        class TestStore extends Store {
+          count = this.atom(5);
+
+          // Only care about whether count is positive/negative, ignore exact value
+          countStatus = this.deriveAtom(
+            [this.count],
+            (count) => ({ isPositive: count > 0, value: count }),
+            {
+              type: 'custom',
+              compare: (a, b) => a.isPositive === b.isPositive,
+            },
+          );
+
+          constructor() {
+            super();
+            this.watchAtom(this.countStatus, callback);
+          }
+        }
+
+        const store = storeContainer.get(TestStore);
+
+        // Still positive, should not notify
+        store.count.value = 10;
+        expect(callback).not.toHaveBeenCalled();
+
+        // Changed from positive to negative, should notify
+        store.count.value = -1;
+        expect(callback).toHaveBeenCalledWith({ isPositive: false, value: -1 });
+
+        storeContainer.remove(TestStore);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR introduces comprehensive memoization support for both atoms and derived atoms in Nucleux. The implementation provides three memoization strategies: shallow equality (default, maintaining backward compatibility), deep equality using fast-deep-equal/es6 for complex objects and arrays, and custom comparators for specialized use cases.

Memoization is configured through the new `memoization` option in `AtomOptions`, and derived atoms can now accept memoization options as a third parameter. This enhancement further improves atom updates and component re-renders when atom values haven't meaningfully changed, building upon Nucleux's existing atomic update system while maintaining the library's simplicity and zero-boilerplate philosophy.