### PR TITLE
Add simple debugging for atom change logging

### DIFF
--- a/src/__tests__/Atom.test.ts
+++ b/src/__tests__/Atom.test.ts
@@ -267,6 +267,16 @@ describe('Atom tests', () => {
 
       expect(callback).toHaveBeenCalledWith('immediate');
     });
+
+    it('should get the previous value when required by arity', () => {
+      const value = new Atom('previous');
+      const callback = jest.fn((current, previous) => ({ current, previous }));
+      value.subscribe(callback, true);
+
+      value.value = 'current';
+
+      expect(callback).toHaveBeenCalledWith('current', 'previous');
+    });
   });
 
   describe('unsubscribe tests', () => {

--- a/src/debug-utils.ts
+++ b/src/debug-utils.ts
@@ -1,0 +1,21 @@
+interface AtomChangeLogData {
+  storeName: string;
+  atomName: string;
+  newValue: any;
+  previousValue?: any;
+  timestamp: number;
+}
+
+export function logAtomChange(logData: AtomChangeLogData): void {
+  console.group(
+    `%c[NUCLEUX] %c${logData.storeName}.${logData.atomName}`,
+    'color: #6366f1; font-weight: bold; font-size: 12px;',
+    'color: #374151; font-weight: bold; font-size: 12px;',
+  );
+  console.log('Previous:', logData.previousValue ?? '(N/A)');
+  console.log('Current:', logData.newValue);
+  console.log('Timestamp:', new Date(logData.timestamp).toISOString());
+  console.log('Store:', logData.storeName);
+  console.log('Atom:', logData.atomName);
+  console.groupEnd();
+}


### PR DESCRIPTION
Adds simple debugging capabilities to Nucleux stores via console logging. Provides immediate visibility into atom state changes during development.

- New `enableDebug()` method on Store class
- Console logging for all atom changes with previous/current values
- Styled console output with timestamps and store context
- Zero-configuration debugging that works in all environments