### PR TITLE
Add NextJS SSR support by providing getServerSnapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added layered memoization support to atoms and derived atoms with
   shallow (default), deep, and custom comparator options to further
   improve atom updates and component re-renders.
+- Added `enableDebug()` to Store class for console-based debugging.
+- Enhanced atom subscribe method to support previous value in callbacks.
+- Console logging for atom changes with previous/current values and
+  timestamps.
 
 ### Changed
 
 - Updated logo view-box and reduce logo size in docs.
+- Updated atom subscribe callback signature to optionally include
+  previous value.
+- Improved atom subscriber error handling.
+
+### Fixed
+
+- Fixed NextJS SSR compatibility by adding getServerSnapshot parameter
+  to useSyncExternalStore hooks.
 
 ## [1.2.2] - 2025-05-31
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -55,7 +55,7 @@ function useStore<S extends Store>(store: StoreConstructable<S>): S {
     ];
   }, [store]);
 
-  return useSyncExternalStore(cleanup, getStore);
+  return useSyncExternalStore(cleanup, getStore, getStore);
 }
 
 /**
@@ -115,7 +115,7 @@ function useValue<V, S extends Store, K extends keyof S>(
       ];
     }, [atomOrStore, atomKey]);
 
-    return useSyncExternalStore(subscribe, getter);
+    return useSyncExternalStore(subscribe, getter, getter);
   }
 
   if (atomKey !== undefined) {
@@ -145,7 +145,7 @@ function useValue<V, S extends Store, K extends keyof S>(
       ];
     }, [atomOrStore, atomKey]);
 
-    return useSyncExternalStore(subscribe, getter);
+    return useSyncExternalStore(subscribe, getter, getter);
   }
 
   throw new Error('Invalid arguments to useValue');
@@ -232,7 +232,7 @@ function useNucleux<S extends Store>(
     ];
   }, [store]);
 
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 export { useNucleux, useStore, useValue };


### PR DESCRIPTION
Added the required `getServerSnapshot` parameter to all `useSyncExternalStore` calls in the hooks:
- `useStore`
- `useValue` (both overloads)
- `useNucleux`

The same snapshot function is used for both client and server to ensure consistent initial state during SSR and hydration.