### PR TITLE
Fix SSR support with getServerSnapshot for useSyncExternalStore hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Enhanced atom subscribe method to support previous value in callbacks.
 - Console logging for atom changes with previous/current values and
   timestamps.
+- Added initialValue property to atom interfaces for accessing the
+  original atom value.
+- Added isServerSnapshot parameter to getStoreProxy utility function for
+  SSR support.
 
 ### Changed
 
@@ -26,11 +30,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Updated atom subscribe callback signature to optionally include
   previous value.
 - Improved atom subscriber error handling.
+- Updated all hooks (useStore, useValue, useNucleux) to provide proper
+  server-side snapshots for SSR.
+- Moved `use-sync-external-store` as a peer dependency.
 
 ### Fixed
 
 - Fixed NextJS SSR compatibility by adding getServerSnapshot parameter
   to useSyncExternalStore hooks.
+- Fixed SSR hydration mismatches for persisted atoms by using initial
+  values on server-side rendering.
 
 ## [1.2.2] - 2025-05-31
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "auto-bind": "^5.0.1",
         "fast-deep-equal": "^3.1.3",
-        "nanoid": "^3.3.11",
-        "use-sync-external-store": "^1.5.0"
+        "nanoid": "^3.3.11"
       },
       "devDependencies": {
         "@testing-library/react": "^13.4.0",
@@ -34,20 +33,25 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "ts-jest": "^29.3.0",
-        "typescript": "^4.9.5"
+        "typescript": "^4.9.5",
+        "use-sync-external-store": "^1.5.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "react": ">=16.9",
-        "react-native-get-random-values": ">=1.8.0"
+        "react-native-get-random-values": ">=1.8.0",
+        "use-sync-external-store": ">=1.2.0"
       },
       "peerDependenciesMeta": {
         "react": {
           "optional": true
         },
         "react-native-get-random-values": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }
@@ -5317,6 +5321,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5517,6 +5522,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6414,6 +6420,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -7275,6 +7282,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
       "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -66,23 +66,27 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "ts-jest": "^29.3.0",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "use-sync-external-store": "^1.5.0"
   },
   "dependencies": {
     "auto-bind": "^5.0.1",
     "fast-deep-equal": "^3.1.3",
-    "nanoid": "^3.3.11",
-    "use-sync-external-store": "^1.5.0"
+    "nanoid": "^3.3.11"
   },
   "peerDependencies": {
     "react": ">=16.9",
-    "react-native-get-random-values": ">=1.8.0"
+    "react-native-get-random-values": ">=1.8.0",
+    "use-sync-external-store": ">=1.2.0"
   },
   "peerDependenciesMeta": {
     "react": {
       "optional": true
     },
     "react-native-get-random-values": {
+      "optional": true
+    },
+    "use-sync-external-store": {
       "optional": true
     }
   }

--- a/src/Atom.ts
+++ b/src/Atom.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid';
 
 interface ReadOnlyAtomInterface<V> {
   readonly value: V;
+  readonly initialValue: V;
   subscribe: (
     callback: (value: V, previousValue?: V) => void,
     immediate?: boolean,
@@ -49,12 +50,14 @@ export interface AtomOptions<V> {
 
 class Atom<V> implements AtomInterface<V> {
   private _value: V;
+  private _initialValue: V;
   private subscribers: Map<string, Subscriber<V>> = new Map();
   private persistence?: AtomPersistenceOptions;
   private memoization?: AtomMemoizationOptions<V>;
 
   constructor(initialValue: V, options?: AtomOptions<V>) {
     this._value = initialValue;
+    this._initialValue = initialValue;
     this.persistence = options?.persistence;
     this.memoization = options?.memoization;
 
@@ -112,6 +115,10 @@ class Atom<V> implements AtomInterface<V> {
         console.error('Error in atom subscriber:', error);
       }
     }
+  }
+
+  public get initialValue(): V {
+    return this._initialValue;
   }
 
   public get value(): V {

--- a/src/__tests__/Atom.test.ts
+++ b/src/__tests__/Atom.test.ts
@@ -18,50 +18,59 @@ describe('Atom tests', () => {
   describe('getter tests', () => {
     it('should get the current value', () => {
       const initialValue = 'test value';
-      const value = new Atom(initialValue);
+      const testAtom = new Atom(initialValue);
 
-      expect(value.value).toBe(initialValue);
+      expect(testAtom.value).toBe(initialValue);
+    });
+
+    it('should get the initial value', () => {
+      const initialValue = 'test value';
+      const testAtom = new Atom(initialValue);
+
+      testAtom.value = 'new value';
+
+      expect(testAtom.initialValue).toBe(initialValue);
     });
   });
 
   describe('publish tests', () => {
     it('should update to the new value', () => {
-      const value = new Atom('');
+      const testAtom = new Atom('');
 
-      value.value = 'test';
+      testAtom.value = 'test';
 
-      expect(value.value).toBe('test');
+      expect(testAtom.value).toBe('test');
     });
 
     describe('memoization tests', () => {
       describe('shallow memoization (default)', () => {
         it('should publish when value changes', () => {
-          const value = new Atom('initial');
+          const testAtom = new Atom('initial');
           const callback = jest.fn();
-          value.subscribe(callback);
+          testAtom.subscribe(callback);
 
-          value.value = 'changed';
+          testAtom.value = 'changed';
 
           expect(callback).toHaveBeenCalledWith('changed');
         });
 
         it('should skip publish when value is identical', () => {
-          const value = new Atom('test');
+          const testAtom = new Atom('test');
           const callback = jest.fn();
-          value.subscribe(callback);
+          testAtom.subscribe(callback);
 
-          value.value = 'test';
+          testAtom.value = 'test';
 
           expect(callback).not.toHaveBeenCalled();
         });
 
         it('should skip publish for same object reference', () => {
           const obj = { name: 'John' };
-          const value = new Atom(obj);
+          const testAtom = new Atom(obj);
           const callback = jest.fn();
-          value.subscribe(callback);
+          testAtom.subscribe(callback);
 
-          value.value = obj;
+          testAtom.value = obj;
 
           expect(callback).not.toHaveBeenCalled();
         });
@@ -69,58 +78,60 @@ describe('Atom tests', () => {
 
       describe('deep memoization', () => {
         it('should skip publish when object content is identical', () => {
-          const value = new Atom(
+          const testAtom = new Atom(
             { name: 'John', age: 30 },
             {
               memoization: { type: 'deep' },
             },
           );
           const callback = jest.fn();
-          value.subscribe(callback);
+          testAtom.subscribe(callback);
 
-          value.value = { name: 'John', age: 30 };
+          testAtom.value = { name: 'John', age: 30 };
 
           expect(callback).not.toHaveBeenCalled();
         });
 
         it('should publish when object content changes', () => {
-          const value = new Atom(
+          const testAtom = new Atom(
             { name: 'John', age: 30 },
             {
               memoization: { type: 'deep' },
             },
           );
           const callback = jest.fn();
-          value.subscribe(callback);
+          testAtom.subscribe(callback);
 
-          value.value = { name: 'John', age: 31 };
+          testAtom.value = { name: 'John', age: 31 };
 
           expect(callback).toHaveBeenCalledWith({ name: 'John', age: 31 });
         });
 
         it('should handle arrays with deep equality', () => {
-          const value = new Atom([1, 2, 3], {
+          const testAtom = new Atom([1, 2, 3], {
             memoization: { type: 'deep' },
           });
           const callback = jest.fn();
-          value.subscribe(callback);
+          testAtom.subscribe(callback);
 
-          value.value = [1, 2, 3];
+          testAtom.value = [1, 2, 3];
 
           expect(callback).not.toHaveBeenCalled();
         });
 
         it('should handle nested objects with deep equality', () => {
-          const value = new Atom(
+          const testAtom = new Atom(
             { user: { name: 'John', settings: { theme: 'dark' } } },
             {
               memoization: { type: 'deep' },
             },
           );
           const callback = jest.fn();
-          value.subscribe(callback);
+          testAtom.subscribe(callback);
 
-          value.value = { user: { name: 'John', settings: { theme: 'dark' } } };
+          testAtom.value = {
+            user: { name: 'John', settings: { theme: 'dark' } },
+          };
 
           expect(callback).not.toHaveBeenCalled();
         });
@@ -128,7 +139,7 @@ describe('Atom tests', () => {
 
       describe('custom memoization', () => {
         it('should use custom comparator function', () => {
-          const value = new Atom(
+          const testAtom = new Atom(
             { name: 'John', age: 25 },
             {
               memoization: {
@@ -138,15 +149,15 @@ describe('Atom tests', () => {
             },
           );
           const callback = jest.fn();
-          value.subscribe(callback);
+          testAtom.subscribe(callback);
 
-          value.value = { name: 'John', age: 30 };
+          testAtom.value = { name: 'John', age: 30 };
 
           expect(callback).not.toHaveBeenCalled();
         });
 
         it('should publish when custom comparator returns false', () => {
-          const value = new Atom(
+          const testAtom = new Atom(
             { name: 'John', age: 25 },
             {
               memoization: {
@@ -156,21 +167,21 @@ describe('Atom tests', () => {
             },
           );
           const callback = jest.fn();
-          value.subscribe(callback);
+          testAtom.subscribe(callback);
 
-          value.value = { name: 'Jane', age: 25 };
+          testAtom.value = { name: 'Jane', age: 25 };
 
           expect(callback).toHaveBeenCalledWith({ name: 'Jane', age: 25 });
         });
 
         it('should fallback to shallow equality when compare function is not provided', () => {
-          const value = new Atom('test', {
+          const testAtom = new Atom('test', {
             memoization: { type: 'custom' },
           });
           const callback = jest.fn();
-          value.subscribe(callback);
+          testAtom.subscribe(callback);
 
-          value.value = 'test';
+          testAtom.value = 'test';
 
           expect(callback).not.toHaveBeenCalled();
         });
@@ -182,11 +193,13 @@ describe('Atom tests', () => {
         const expectedValue = 'initial value';
         const persistKey = 'persisted_key';
         const newValue = 'test';
-        const value = new Atom(expectedValue, { persistence: { persistKey } });
+        const testAtom = new Atom(expectedValue, {
+          persistence: { persistKey },
+        });
 
         await new Promise(process.nextTick);
 
-        value.value = newValue;
+        testAtom.value = newValue;
 
         expect(setItemSpy).toHaveBeenCalledWith(
           persistKey,
@@ -195,38 +208,38 @@ describe('Atom tests', () => {
       });
 
       it('should not persist the new value if persist key is not defined', () => {
-        const value = new Atom<number>(2);
+        const testAtom = new Atom<number>(2);
 
-        value.value = 3;
+        testAtom.value = 3;
 
         expect(setItemSpy).not.toHaveBeenCalled();
       });
 
       it('should not persist the new value if persist key is defined and value has not changed', () => {
         const persistKey = 'persisted_key';
-        const value = new Atom(2, { persistence: { persistKey } });
+        const testAtom = new Atom(2, { persistence: { persistKey } });
         setItemSpy.mockClear();
 
-        value.value = 2;
+        testAtom.value = 2;
 
         expect(setItemSpy).not.toHaveBeenCalled();
       });
 
       it('should not persist the new value if persist key is defined and value is undefined', () => {
         const persistKey = 'persisted_key';
-        const value = new Atom<number | undefined>(2, {
+        const testAtom = new Atom<number | undefined>(2, {
           persistence: { persistKey },
         });
         setItemSpy.mockClear();
 
-        value.value = undefined;
+        testAtom.value = undefined;
 
         expect(setItemSpy).not.toHaveBeenCalled();
       });
 
       it('should not persist when memoization prevents update', () => {
         const persistKey = 'memoized_key';
-        const value = new Atom(
+        const testAtom = new Atom(
           { name: 'John' },
           {
             persistence: { persistKey },
@@ -235,7 +248,7 @@ describe('Atom tests', () => {
         );
         setItemSpy.mockClear();
 
-        value.value = { name: 'John' };
+        testAtom.value = { name: 'John' };
 
         expect(setItemSpy).not.toHaveBeenCalled();
       });
@@ -244,36 +257,36 @@ describe('Atom tests', () => {
 
   describe('subscribe tests', () => {
     it('should create the subscription', () => {
-      const value = new Atom('');
+      const testAtom = new Atom('');
       const callback = jest.fn();
-      value.subscribe(callback);
+      testAtom.subscribe(callback);
 
       const newVal = 'test';
-      value.value = newVal;
+      testAtom.value = newVal;
 
       expect(callback).toHaveBeenCalledWith(newVal);
     });
 
     it('should return the subscription ID', () => {
-      const value = new Atom(null);
+      const testAtom = new Atom(null);
 
-      expect(value.subscribe(() => undefined)).toBe(mockSubId);
+      expect(testAtom.subscribe(() => undefined)).toBe(mockSubId);
     });
 
     it('should get the value when immediate is set', () => {
-      const value = new Atom('immediate');
+      const testAtom = new Atom('immediate');
       const callback = jest.fn();
-      value.subscribe(callback, true);
+      testAtom.subscribe(callback, true);
 
       expect(callback).toHaveBeenCalledWith('immediate');
     });
 
     it('should get the previous value when required by arity', () => {
-      const value = new Atom('previous');
+      const testAtom = new Atom('previous');
       const callback = jest.fn((current, previous) => ({ current, previous }));
-      value.subscribe(callback, true);
+      testAtom.subscribe(callback, true);
 
-      value.value = 'current';
+      testAtom.value = 'current';
 
       expect(callback).toHaveBeenCalledWith('current', 'previous');
     });
@@ -281,19 +294,19 @@ describe('Atom tests', () => {
 
   describe('unsubscribe tests', () => {
     it('should return false if subscriber ID is not found', () => {
-      const value = new Atom('');
+      const testAtom = new Atom('');
 
-      expect(value.unsubscribe('subId')).toBe(false);
+      expect(testAtom.unsubscribe('subId')).toBe(false);
     });
 
     it('should return true if the subscriber ID is found and deleted', () => {
-      const value = new Atom('');
+      const testAtom = new Atom('');
       const callback = jest.fn();
-      const subId = value.subscribe(callback);
+      const subId = testAtom.subscribe(callback);
 
-      expect(value.unsubscribe(subId)).toBe(true);
+      expect(testAtom.unsubscribe(subId)).toBe(true);
 
-      value.value = 'test';
+      testAtom.value = 'test';
 
       expect(callback).not.toHaveBeenCalled();
     });
@@ -307,19 +320,19 @@ describe('Atom tests', () => {
 
       await new Promise(process.nextTick);
 
-      const value = new Atom(null, { persistence: { persistKey } });
+      const testAtom = new Atom(null, { persistence: { persistKey } });
 
       await new Promise(process.nextTick);
 
       expect(getItemSpy).toHaveBeenCalledWith(persistKey);
-      expect(value.value).toEqual(expectedValue);
+      expect(testAtom.value).toEqual(expectedValue);
     });
 
     it('should create new persisted value when persisted value does not exist', async () => {
       const expectedValue = false;
       const persistKey = 'persisted_key';
 
-      const value = new Atom(expectedValue, { persistence: { persistKey } });
+      const testAtom = new Atom(expectedValue, { persistence: { persistKey } });
 
       await new Promise(process.nextTick);
 
@@ -327,7 +340,7 @@ describe('Atom tests', () => {
         persistKey,
         JSON.stringify(expectedValue),
       );
-      expect(value.value).toEqual(expectedValue);
+      expect(testAtom.value).toEqual(expectedValue);
     });
 
     it('should not create new persisted value when persisted key is not defined', async () => {
@@ -351,21 +364,21 @@ describe('Atom tests', () => {
           Promise.resolve(JSON.stringify(expectedValue)),
         );
 
-        const value = new Atom(null, {
+        const testAtom = new Atom(null, {
           persistence: { persistKey, storage: customStorage },
         });
 
         await new Promise(process.nextTick);
 
         expect(customStorage.getItem).toHaveBeenCalledWith(persistKey);
-        expect(value.value).toEqual(expectedValue);
+        expect(testAtom.value).toEqual(expectedValue);
       });
 
       it('should create new persisted value when persisted value does not exist', async () => {
         const expectedValue = false;
         const persistKey = 'persisted_key';
 
-        const value = new Atom(expectedValue, {
+        const testAtom = new Atom(expectedValue, {
           persistence: { persistKey, storage: customStorage },
         });
 
@@ -375,7 +388,7 @@ describe('Atom tests', () => {
           persistKey,
           JSON.stringify(expectedValue),
         );
-        expect(value.value).toEqual(expectedValue);
+        expect(testAtom.value).toEqual(expectedValue);
       });
 
       it('should not create new persisted value when persisted key is not defined', async () => {

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
 import { nanoid } from 'nanoid';
 
-import { generateStoreDefinition } from '../utils';
+import { Store } from '../Store';
+import { generateStoreDefinition, getStoreProxy } from '../utils';
 
 jest.mock('nanoid');
 
@@ -19,6 +20,66 @@ describe('utils tests', () => {
         storeId: mockStoreId,
         storeClass: MockStore,
       });
+    });
+  });
+
+  describe('getStoreProxy', () => {
+    class TestStore extends Store {
+      count = this.atom(5); // Initial value: 5
+
+      increment() {
+        this.count.value++;
+      }
+    }
+
+    let store: TestStore;
+
+    beforeEach(() => {
+      store = new TestStore();
+    });
+
+    it('should return method functions', () => {
+      const proxy = getStoreProxy(store);
+      expect(typeof proxy.increment).toBe('function');
+    });
+
+    it('should return initial atom value', () => {
+      const proxy = getStoreProxy(store);
+      expect(proxy.count).toBe(5);
+    });
+
+    it('should return undefined for non-existent properties', () => {
+      const proxy = getStoreProxy(store);
+      expect((proxy as any).nonExistent).toBeUndefined();
+    });
+
+    it('should return current values in client mode after changes', () => {
+      const proxy = getStoreProxy(store, false);
+
+      store.count.value = 10;
+
+      expect(proxy.count).toBe(10);
+    });
+
+    it('should return initial values in server mode even after changes', () => {
+      const proxy = getStoreProxy(store, true);
+
+      store.count.value = 10;
+
+      expect(proxy.count).toBe(5);
+    });
+
+    it('should prevent setting values and log warning', () => {
+      const proxy = getStoreProxy(store);
+
+      expect(() => {
+        (proxy as any).count = 99;
+      }).toThrow('set');
+
+      expect(store.count.value).toBe(5);
+      expect(console.warn).toHaveBeenCalledWith(
+        'Cannot modify store values directly. Use store methods instead.',
+      );
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,22 +21,27 @@ function generateStoreDefinition<S>(
   };
 }
 
-function getStoreProxy<S extends Store>(storeInstance: S) {
+function getStoreProxy<S extends Store>(
+  storeInstance: S,
+  isServerSnapshot = false,
+) {
   return new Proxy(storeInstance, {
     get(_, prop): unknown {
       const key = prop.toString();
 
       if (Object.prototype.hasOwnProperty.call(storeInstance, key)) {
-        const value = storeInstance[key as keyof S];
+        const storeMember = storeInstance[key as keyof S];
 
         // Check for method first
-        if (isFunction(value)) {
-          return value.bind(storeInstance);
+        if (isFunction(storeMember)) {
+          return storeMember.bind(storeInstance);
         }
 
         // Then check for atom
-        if (isAtom(value) && value instanceof Atom) {
-          return value.value;
+        if (isAtom(storeMember) && storeMember instanceof Atom) {
+          return isServerSnapshot
+            ? storeMember.initialValue
+            : storeMember.value;
         }
       }
 


### PR DESCRIPTION
Fixes NextJS SSR compatibility by adding the required getServerSnapshot parameter to all useSyncExternalStore calls in useStore, useValue, and useNucleux hooks. This prevents hydration mismatches for persisted atoms by using initial values during server-side rendering while maintaining current values for client-side updates.

Changes:
- Added initialValue property to atom interfaces and implementation
- Enhanced getStoreProxy with optional isServerSnapshot parameter for SSR support
- Updated all hooks to provide proper server-side snapshots
- Moved use-sync-external-store from dependency to peer dependency
- Added comprehensive tests for getStoreProxy client/server modes
- Improved atom test coverage and variable naming consistency