### PR TITLE
Add reset functionality for atoms and stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added BetaList featured badge.
+- Added `reset()` method to atoms for resetting values to initial state
+  and clearing persisted data.
+- Added `reset()` method to Store class for bulk atom reset operations
+  with granular control.
+- Added `clearPersistedData()` convenience method to Store class for
+  clearing storage without affecting current values.
+- Added `resetValues()` convenience method to Store class for resetting
+  values without affecting persisted data.
 
 ## [1.3.0] - 2025-06-22
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,66 @@ class TodoStore extends Store {
 }
 ```
 
+### Reset Functionality
+
+Reset atoms to their initial values and clear persisted data when needed.
+
+#### Individual Atom Reset
+
+```javascript
+class UserStore extends Store {
+  theme = this.atom('light', { persistence: { persistKey: 'theme' } });
+  username = this.atom('guest');
+}
+
+const userStore = useStore(UserStore);
+
+// Reset atom to initial value and clear storage
+await userStore.theme.reset();
+
+// Reset value but keep persisted data
+await userStore.theme.reset({ clearPersisted: false });
+
+// Clear persisted data but keep current value
+await userStore.theme.reset({ resetValue: false });
+```
+
+#### Store-Level Reset
+
+```javascript
+class AppStore extends Store {
+  theme = this.atom('light', { persistence: { persistKey: 'theme' } });
+  language = this.atom('en', { persistence: { persistKey: 'language' } });
+  isOnline = this.atom(true); // No persistence
+}
+
+const appStore = useStore(AppStore);
+
+// Reset all atoms (values + persistence)
+await appStore.reset();
+
+// Reset specific atoms only
+await appStore.reset({ atomKeys: ['theme', 'language'] });
+
+// Convenience methods
+await appStore.clearPersistedData(); // Clear persisted data only
+await appStore.resetValues(); // Reset values only
+```
+
+#### Common Use Cases
+
+```javascript
+// User logout - clear sensitive data
+await userStore.reset({
+  atomKeys: ['profile', 'preferences'],
+  resetValues: true,
+  clearPersisted: true,
+});
+
+// App settings reset
+await settingsStore.reset();
+```
+
 ## React Native Setup
 
 Install the polyfill and import it before Nucleux:
@@ -434,6 +494,67 @@ constructor() {
     this.enableDebug();
   }
 }
+```
+
+#### `atom.reset(options?)`
+
+Reset atom to initial value and/or clear persisted data.
+
+**Options:**
+
+- `resetValue?: boolean` - Reset value to initial (default: true)
+- `clearPersisted?: boolean` - Clear persisted data from storage (default: true)
+
+```javascript
+// Reset everything
+await userAtom.reset();
+
+// Reset value only
+await userAtom.reset({ clearPersisted: false });
+
+// Clear storage only
+await userAtom.reset({ resetValue: false });
+```
+
+#### `this.reset(options?)`
+
+Reset multiple atoms in the store.
+
+**Options:**
+
+- `resetValues?: boolean` - Reset values to initial (default: true)
+- `clearPersisted?: boolean` - Clear persisted data (default: true)
+- `atomKeys?: string[]` - Specific atoms to reset (default: all atoms)
+
+```javascript
+// Reset all atoms
+await this.reset();
+
+// Reset specific atoms
+await this.reset({ atomKeys: ['theme', 'language'] });
+
+// Custom combination
+await this.reset({
+  resetValues: false,
+  clearPersisted: true,
+  atomKeys: ['cache'],
+});
+```
+
+#### `this.clearPersistedData()`
+
+Clear all persisted data without affecting current values.
+
+```javascript
+await this.clearPersistedData();
+```
+
+#### `this.resetValues()`
+
+Reset all atom values without affecting persisted data.
+
+```javascript
+await this.resetValues();
 ```
 
 ### React Hooks

--- a/docs/README.md
+++ b/docs/README.md
@@ -252,6 +252,66 @@ class TodoStore extends Store {
 }
 ```
 
+### Reset Functionality
+
+Reset atoms to their initial values and clear persisted data when needed.
+
+#### Individual Atom Reset
+
+```javascript
+class UserStore extends Store {
+  theme = this.atom('light', { persistence: { persistKey: 'theme' } });
+  username = this.atom('guest');
+}
+
+const userStore = useStore(UserStore);
+
+// Reset atom to initial value and clear storage
+await userStore.theme.reset();
+
+// Reset value but keep persisted data
+await userStore.theme.reset({ clearPersisted: false });
+
+// Clear persisted data but keep current value
+await userStore.theme.reset({ resetValue: false });
+```
+
+#### Store-Level Reset
+
+```javascript
+class AppStore extends Store {
+  theme = this.atom('light', { persistence: { persistKey: 'theme' } });
+  language = this.atom('en', { persistence: { persistKey: 'language' } });
+  isOnline = this.atom(true); // No persistence
+}
+
+const appStore = useStore(AppStore);
+
+// Reset all atoms (values + persistence)
+await appStore.reset();
+
+// Reset specific atoms only
+await appStore.reset({ atomKeys: ['theme', 'language'] });
+
+// Convenience methods
+await appStore.clearPersistedData(); // Clear persisted data only
+await appStore.resetValues(); // Reset values only
+```
+
+#### Common Use Cases
+
+```javascript
+// User logout - clear sensitive data
+await userStore.reset({
+  atomKeys: ['profile', 'preferences'],
+  resetValues: true,
+  clearPersisted: true,
+});
+
+// App settings reset
+await settingsStore.reset();
+```
+
 ## React Native Setup
 
 Install the polyfill and import it before Nucleux:
@@ -422,6 +482,67 @@ constructor() {
     this.enableDebug();
   }
 }
+```
+
+#### `atom.reset(options?)`
+
+Reset atom to initial value and/or clear persisted data.
+
+**Options:**
+
+- `resetValue?: boolean` - Reset value to initial (default: true)
+- `clearPersisted?: boolean` - Clear persisted data from storage (default: true)
+
+```javascript
+// Reset everything
+await userAtom.reset();
+
+// Reset value only
+await userAtom.reset({ clearPersisted: false });
+
+// Clear storage only
+await userAtom.reset({ resetValue: false });
+```
+
+#### `this.reset(options?)`
+
+Reset multiple atoms in the store.
+
+**Options:**
+
+- `resetValues?: boolean` - Reset values to initial (default: true)
+- `clearPersisted?: boolean` - Clear persisted data (default: true)
+- `atomKeys?: string[]` - Specific atoms to reset (default: all atoms)
+
+```javascript
+// Reset all atoms
+await this.reset();
+
+// Reset specific atoms
+await this.reset({ atomKeys: ['theme', 'language'] });
+
+// Custom combination
+await this.reset({
+  resetValues: false,
+  clearPersisted: true,
+  atomKeys: ['cache'],
+});
+```
+
+#### `this.clearPersistedData()`
+
+Clear all persisted data without affecting current values.
+
+```javascript
+await this.clearPersistedData();
+```
+
+#### `this.resetValues()`
+
+Reset all atom values without affecting persisted data.
+
+```javascript
+await this.resetValues();
 ```
 
 ### React Hooks

--- a/src/Atom.ts
+++ b/src/Atom.ts
@@ -14,11 +14,11 @@ interface ReadOnlyAtomInterface<V> {
     immediate?: boolean,
   ) => string;
   unsubscribe: (subId: string) => boolean;
+  reset(options?: AtomResetOptions): Promise<void>;
 }
 
 interface AtomInterface<V> extends ReadOnlyAtomInterface<V> {
   value: V;
-  reset(options?: AtomResetOptions): Promise<void>;
 }
 
 type Subscriber<V> = {

--- a/src/Atom.ts
+++ b/src/Atom.ts
@@ -1,6 +1,11 @@
 import isEqual from 'fast-deep-equal/es6';
 import { nanoid } from 'nanoid';
 
+interface AtomResetOptions {
+  resetValue?: boolean;
+  clearPersisted?: boolean;
+}
+
 interface ReadOnlyAtomInterface<V> {
   readonly value: V;
   readonly initialValue: V;
@@ -13,6 +18,7 @@ interface ReadOnlyAtomInterface<V> {
 
 interface AtomInterface<V> extends ReadOnlyAtomInterface<V> {
   value: V;
+  reset(options?: AtomResetOptions): Promise<void>;
 }
 
 type Subscriber<V> = {
@@ -30,7 +36,7 @@ type PromisifyMethods<T> = {
 };
 
 export type SupportedStorage = PromisifyMethods<
-  Pick<Storage, 'getItem' | 'setItem'>
+  Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
 >;
 
 export interface AtomMemoizationOptions<V> {
@@ -164,6 +170,28 @@ class Atom<V> implements AtomInterface<V> {
     }
 
     return this.subscribers.delete(subId);
+  }
+
+  public async reset(options: AtomResetOptions = {}) {
+    const { resetValue = true, clearPersisted = true } = options;
+
+    if (clearPersisted && this.persistence) {
+      const { persistKey, storage = localStorage } = this.persistence;
+      try {
+        await storage.removeItem(persistKey);
+      } catch (error) {
+        console.error(
+          `Failed to clear persisted data for key ${persistKey}:`,
+          error,
+        );
+      }
+    }
+
+    if (resetValue) {
+      const previousValue = this._value;
+      this._value = this._initialValue;
+      this.notifySubscribers(this._initialValue, previousValue);
+    }
   }
 }
 

--- a/src/__tests__/Store.test.ts
+++ b/src/__tests__/Store.test.ts
@@ -380,15 +380,13 @@ describe('Store tests', () => {
     });
 
     it('should not reset anything for non-existent atom', async () => {
-      const store = new ResetTestStore();
+      testStore.persistedAtom1.value = 'changed1';
+      testStore.persistedAtom2.value = 'changed2';
 
-      store.persistedAtom1.value = 'changed1';
-      store.persistedAtom2.value = 'changed2';
+      await testStore.reset({ atomKeys: ['nonExistentAtom'] });
 
-      await store.reset({ atomKeys: ['nonExistentAtom'] });
-
-      expect(store.persistedAtom1.value).toBe('changed1');
-      expect(store.persistedAtom2.value).toBe('changed2');
+      expect(testStore.persistedAtom1.value).toBe('changed1');
+      expect(testStore.persistedAtom2.value).toBe('changed2');
     });
 
     it('should clear persisted data without resetting values', async () => {


### PR DESCRIPTION
This PR adds functionality to reset individual atoms or bulk reset multiple atoms at the store level. The new `atom.reset()` method provides granular control over resetting values to their initial state and clearing persisted data from storage, while the store-level `reset()` method enables bulk operations with the same level of control. The implementation includes convenient methods `clearPersistedData()` and `resetValues()`.